### PR TITLE
Write back updated value, after successfully sending it to the heat pump

### DIFF
--- a/custom_components/idm_heatpump/coordinator.py
+++ b/custom_components/idm_heatpump/coordinator.py
@@ -53,7 +53,13 @@ class IdmHeatpumpDataUpdateCoordinator(DataUpdateCoordinator[dict[str, any]]):
         """Update data via library."""
         try:
             async with timeout(self.timeout_delta.total_seconds()):
-                return await self.heatpump.async_write_value(address, value)
+                result = await self.heatpump.async_write_value(address, value)
+                
+                updated_data = self.data.copy() if self.data else {}
+                updated_data[address.name] = value
+                self.async_set_updated_data(updated_data)
+
+                return result
         except TimeoutError as e:
             LOGGER.error("timeout while writing")
             raise e


### PR DESCRIPTION
After our short conversation here https://github.com/kodebach/hacs-idm-heatpump/discussions/204 i have it a try.
It's my very first time writing any code for home-assistant integrations, so forgive me if it's now how to do it :-) 
At least it works for me. I would assume that the coordinator is where everything goes through? So I simply take the value and the address and update self.data with it.
In my personal testing, setting the heat pumps mode, it works and the change is reflected immediately.