### PR TITLE
feat: add "force_update" option to force sensor updates on every refresh

### DIFF
--- a/custom_components/idm_heatpump/config_flow.py
+++ b/custom_components/idm_heatpump/config_flow.py
@@ -21,6 +21,7 @@ from .const import (
     MAX_ZONE_COUNT,
     MIN_REFRESH_INTERVAL,
     OPT_ALLOW_FAST_REFRESH,
+    OPT_FORCE_UPDATE,
     OPT_HEATING_CIRCUITS,
     OPT_MAX_POWER_USAGE,
     OPT_READ_WITHOUT_GROUPS,
@@ -230,6 +231,10 @@ def _async_step_base_options(
             vol.Required(
                 OPT_READ_WITHOUT_GROUPS,
                 default=options.get(OPT_READ_WITHOUT_GROUPS, False),
+            ): bool,
+            vol.Required(
+                OPT_FORCE_UPDATE,
+                default=options.get(OPT_FORCE_UPDATE, False),
             ): bool,
             vol.Optional(
                 OPT_MAX_POWER_USAGE,

--- a/custom_components/idm_heatpump/const.py
+++ b/custom_components/idm_heatpump/const.py
@@ -250,6 +250,7 @@ OPT_ZONE_ROOM_COUNT = [f"zone_{i}_room_count" for i in range(MAX_ZONE_COUNT)]
 OPT_ZONE_ROOM_9_RELAY = [f"zone_{i}_room_9_relay" for i in range(MAX_ZONE_COUNT)]
 OPT_READ_WITHOUT_GROUPS = "read_without_groups"
 OPT_MAX_POWER_USAGE = "max_power_usage"
+OPT_FORCE_UPDATE = "force_update"
 
 NAME_POWER_USAGE = "power_current_draw"
 

--- a/custom_components/idm_heatpump/entity.py
+++ b/custom_components/idm_heatpump/entity.py
@@ -15,6 +15,7 @@ from .const import (
     MANUFACTURER,
     MODEL_MAIN,
     MODEL_ZONE,
+    OPT_FORCE_UPDATE,
     SensorFeatures,
 )
 from .coordinator import IdmHeatpumpDataUpdateCoordinator
@@ -37,6 +38,7 @@ class IdmHeatpumpEntity(CoordinatorEntity, Generic[_T]):
         """Create entity."""
         super().__init__(coordinator)
         self.config_entry = config_entry
+        self._attr_force_update = config_entry.options.get(OPT_FORCE_UPDATE, False)
 
     @property
     @abstractmethod

--- a/custom_components/idm_heatpump/translations/de.json
+++ b/custom_components/idm_heatpump/translations/de.json
@@ -13,6 +13,7 @@
                 "data": {
                     "refresh_interval": "Aktualisierungsintervall",
                     "allow_fast_refresh": "Aktualisierungsintervall kleiner 1 min erlauben",
+                    "force_update": "Sensor-Aktualisierung bei jedem Intervall erzwingen",
                     "request_timeout": "Kommunikationstimeout",
                     "heating_circuits": "Heizkreise",
                     "zone_count": "Anzahl Zonenmodule",
@@ -21,6 +22,7 @@
                 },
                 "data_description": {
                     "allow_fast_refresh": "Kurze Aktualisierungsintervalle sind aufgrund von Berichten über mögliche Probleme (siehe [Issue #16]({issue_url})) standardmäßig gesperrt.",
+                    "force_update": "Wenn aktiviert, speichert jeder Sensor bei jeder Aktualisierung einen neuen Zustand, auch wenn sich der Wert nicht geändert hat. Das kann die Größe der Recorder-Datenbank und des Verlaufs deutlich erhöhen. Standardmäßig deaktiviert – nur aktivieren, wenn ein Datenpunkt pro Intervall benötigt wird (z. B. für Statistiken oder Diagramme).",
                     "max_power_usage": "Der Sensor 'Aktuelle Leistungsaufnahme Wärmepumpe' wird auf 'Unknown' gesetzt, falls die Wärmepumpe einen Wert über dem Maximum sendet. Die führt zu Lücken im Verlauf anstelle von unmöglich hohen Werten, welche die Achsenskalierung beeinflussen würden. Wenn kein Wert gesetzt ist, oder 0 als Maximum gesetzt ist, werden alle Werte der Wärmepumpe direkt übernommen."
                 }
             },
@@ -64,6 +66,7 @@
                 "data": {
                     "refresh_interval": "Aktualisierungsintervall",
                     "allow_fast_refresh": "Aktualisierungsintervall kleiner 1 min erlauben",
+                    "force_update": "Sensor-Aktualisierung bei jedem Intervall erzwingen",
                     "request_timeout": "Kommunikationstimeout",
                     "heating_circuits": "Heizkreise",
                     "zone_count": "Anzahl Zonenmodule",
@@ -72,6 +75,7 @@
                 },
                 "data_description": {
                     "allow_fast_refresh": "Kurze Aktualisierungsintervalle sind aufgrund von Berichten über mögliche Probleme (siehe [Issue #16]({issue_url})) standardmäßig gesperrt.",
+                    "force_update": "Wenn aktiviert, speichert jeder Sensor bei jeder Aktualisierung einen neuen Zustand, auch wenn sich der Wert nicht geändert hat. Das kann die Größe der Recorder-Datenbank und des Verlaufs deutlich erhöhen. Standardmäßig deaktiviert – nur aktivieren, wenn ein Datenpunkt pro Intervall benötigt wird (z. B. für Statistiken oder Diagramme).",
                     "max_power_usage": "Der Sensor 'Aktuelle Leistungsaufnahme Wärmepumpe' wird auf 'Unknown' gesetzt, falls die Wärmepumpe einen Wert über dem Maximum sendet. Die führt zu Lücken im Verlauf anstelle von unmöglich hohen Werten, welche die Achsenskalierung beeinflussen würden. Wenn kein Wert gesetzt ist, oder 0 als Maximum gesetzt ist, werden alle Werte der Wärmepumpe direkt übernommen."
                 }
             },

--- a/custom_components/idm_heatpump/translations/en.json
+++ b/custom_components/idm_heatpump/translations/en.json
@@ -13,6 +13,7 @@
                 "data": {
                     "refresh_interval": "Refresh Interval",
                     "allow_fast_refresh": "Allow refresh interval smaller than 1 min",
+                    "force_update": "Force sensor updates on every refresh",
                     "request_timeout": "Communication Timeout",
                     "heating_circuits": "Heating Circuits",
                     "zone_count": "Number of zone modules",
@@ -21,6 +22,7 @@
                 },
                 "data_description": {
                     "allow_fast_refresh": "Short refresh are blocked by default because of reports about possible issues (see [issue #16]({issue_url})).",
+                    "force_update": "When enabled, every sensor records a new state on each refresh even if the value did not change. This can significantly increase the size of the recorder database and history. Leave off unless you need a data point per refresh (e.g. for statistics or charts).",
                     "max_power_usage": "The sensor 'Aktuelle Leistungsaufnahme Wärmepumpe' will be set to 'Unknown', if the heat pump sends a value above the maximum. This creates gaps in the history instead of impossibly high values, which would throw of the axis scaling. If no value is defined or it is set to 0, all values from the heat pump will be used directly."
                 }
             },
@@ -64,6 +66,7 @@
                 "data": {
                     "refresh_interval": "Refresh Interval",
                     "allow_fast_refresh": "Allow refresh interval smaller than 1 min",
+                    "force_update": "Force sensor updates on every refresh",
                     "request_timeout": "Communication Timeout",
                     "heating_circuits": "Heating Circuits",
                     "zone_count": "Number of zone modules",
@@ -72,6 +75,7 @@
                 },
                 "data_description": {
                     "allow_fast_refresh": "Short refresh are blocked by default because of reports about possible issues (see [issue #16]({issue_url})).",
+                    "force_update": "When enabled, every sensor records a new state on each refresh even if the value did not change. This can significantly increase the size of the recorder database and history. Leave off unless you need a data point per refresh (e.g. for statistics or charts).",
                     "max_power_usage": "The sensor 'Aktuelle Leistungsaufnahme Wärmepumpe' will be set to 'Unknown', if the heat pump sends a value above the maximum. This creates gaps in the history instead of impossibly high values, which would throw of the axis scaling. If no value is defined or it is set to 0, all values from the heat pump will be used directly."
                 }
             },


### PR DESCRIPTION
Adds an optional (default off) checkbox in the config/options flow that sets force_update on all IDM sensors and binary sensors, so a new state is recorded on every refresh even when the value is unchanged. Off by default preserves current behaviour. Includes an EN + DE data_description warning about increased recorder/history size, mirroring allow_fast_refresh.