### PR TITLE
Fix hassfest translation validation errors

### DIFF
--- a/custom_components/idm_heatpump/config_flow.py
+++ b/custom_components/idm_heatpump/config_flow.py
@@ -33,6 +33,9 @@ from .const import (
 from .idm_heatpump import IdmHeatpump
 from .sensor_addresses import HeatingCircuit
 
+CONFIG_HELP_URL = "https://github.com/kodebach/hacs-idm-heatpump"
+FAST_REFRESH_ISSUE_URL = "https://github.com/kodebach/hacs-idm-heatpump/issues/16"
+
 
 class IdmHeatpumpFlowHandler(ConfigFlow, domain=DOMAIN):
     """Config flow for IDM heat pump."""
@@ -79,6 +82,7 @@ class IdmHeatpumpFlowHandler(ConfigFlow, domain=DOMAIN):
             step_id="user",
             data_schema=schema,
             errors=errors,
+            description_placeholders={"docs_url": CONFIG_HELP_URL},
         )
 
     async def async_step_options(self, user_input=None):
@@ -94,6 +98,7 @@ class IdmHeatpumpFlowHandler(ConfigFlow, domain=DOMAIN):
             step_id="options",
             data_schema=schema,
             errors=errors,
+            description_placeholders={"issue_url": FAST_REFRESH_ISSUE_URL},
         )
 
     async def async_step_zones(self, user_input=None):
@@ -155,6 +160,7 @@ class IdmHeatpumpOptionsFlowHandler(OptionsFlow):
             step_id="options",
             data_schema=schema,
             errors=errors,
+            description_placeholders={"issue_url": FAST_REFRESH_ISSUE_URL},
         )
 
     async def async_step_zones(self, user_input=None):

--- a/custom_components/idm_heatpump/services.yaml
+++ b/custom_components/idm_heatpump/services.yaml
@@ -17,7 +17,7 @@ set_power:
       selector:
         constant:
           value: true
-          translation_key: acknowledge_set_value
+          label: ""
 
 set_battery:
   fields:
@@ -40,7 +40,7 @@ set_battery:
       selector:
         constant:
           value: true
-          translation_key: acknowledge_set_value
+          label: ""
 
 set_temperature:
   fields:
@@ -61,7 +61,7 @@ set_temperature:
       selector:
         constant:
           value: true
-          translation_key: acknowledge_set_value
+          label: ""
 
 set_humidity:
   fields:
@@ -84,7 +84,7 @@ set_humidity:
       selector:
         constant:
           value: true
-          translation_key: acknowledge_set_value
+          label: ""
 
 set_room_mode:
   fields:
@@ -110,7 +110,7 @@ set_room_mode:
       selector:
         constant:
           value: true
-          translation_key: acknowledge_set_value
+          label: ""
 
 set_circuit_mode:
   fields:
@@ -137,7 +137,7 @@ set_circuit_mode:
       selector:
         constant:
           value: true
-          translation_key: acknowledge_set_value
+          label: ""
 
 set_binary:
   fields:
@@ -155,7 +155,7 @@ set_binary:
       selector:
         constant:
           value: true
-          translation_key: acknowledge_set_value
+          label: ""
 
 set_system_status:
   fields:
@@ -183,4 +183,4 @@ set_system_status:
       selector:
         constant:
           value: true
-          translation_key: acknowledge_set_value
+          label: ""

--- a/custom_components/idm_heatpump/translations/de.json
+++ b/custom_components/idm_heatpump/translations/de.json
@@ -3,7 +3,7 @@
         "step": {
             "user": {
                 "title": "IDM Wärmepumpe",
-                "description": "Für Hilfe mit der Konfiguration: https://github.com/kodebach/hacs-idm-heatpump",
+                "description": "Für Hilfe mit der Konfiguration siehe [hier]({docs_url}).",
                 "data": {
                     "display_name": "Anzeigename",
                     "hostname": "Hostname/IP"
@@ -20,7 +20,7 @@
                     "max_power_usage": "Maximale Leistungsaufnahme"
                 },
                 "data_description": {
-                    "allow_fast_refresh": "Kurze Aktualisierungsintervalle sind aufgrund von Berichten über mögliche Probleme (https://github.com/kodebach/hacs-idm-heatpump/issues/16) standardmäßig gesperrt.",
+                    "allow_fast_refresh": "Kurze Aktualisierungsintervalle sind aufgrund von Berichten über mögliche Probleme (siehe [Issue #16]({issue_url})) standardmäßig gesperrt.",
                     "max_power_usage": "Der Sensor 'Aktuelle Leistungsaufnahme Wärmepumpe' wird auf 'Unknown' gesetzt, falls die Wärmepumpe einen Wert über dem Maximum sendet. Die führt zu Lücken im Verlauf anstelle von unmöglich hohen Werten, welche die Achsenskalierung beeinflussen würden. Wenn kein Wert gesetzt ist, oder 0 als Maximum gesetzt ist, werden alle Werte der Wärmepumpe direkt übernommen."
                 }
             },
@@ -71,7 +71,7 @@
                     "max_power_usage": "Maximale Leistungsaufnahme"
                 },
                 "data_description": {
-                    "allow_fast_refresh": "Kurze Aktualisierungsintervalle sind aufgrund von Berichten über mögliche Probleme (https://github.com/kodebach/hacs-idm-heatpump/issues/16) standardmäßig gesperrt.",
+                    "allow_fast_refresh": "Kurze Aktualisierungsintervalle sind aufgrund von Berichten über mögliche Probleme (siehe [Issue #16]({issue_url})) standardmäßig gesperrt.",
                     "max_power_usage": "Der Sensor 'Aktuelle Leistungsaufnahme Wärmepumpe' wird auf 'Unknown' gesetzt, falls die Wärmepumpe einen Wert über dem Maximum sendet. Die führt zu Lücken im Verlauf anstelle von unmöglich hohen Werten, welche die Achsenskalierung beeinflussen würden. Wenn kein Wert gesetzt ist, oder 0 als Maximum gesetzt ist, werden alle Werte der Wärmepumpe direkt übernommen."
                 }
             },

--- a/custom_components/idm_heatpump/translations/de.json
+++ b/custom_components/idm_heatpump/translations/de.json
@@ -120,7 +120,7 @@
                 },
                 "acknowledge_risk": {
                     "name": "Bestätigung",
-                    "description": "Ich akzeptiere das Risiko"
+                    "description": "Ich habe die Dokumentation von IDM gelesen, weiß was das setzen dieses Wertes bewirkt und akzeptiere das Risiko bei falscher Verwendung."
                 }
             }
         },
@@ -138,7 +138,7 @@
                 },
                 "acknowledge_risk": {
                     "name": "Bestätigung",
-                    "description": "Ich akzeptiere das Risiko"
+                    "description": "Ich habe die Dokumentation von IDM gelesen, weiß was das setzen dieses Wertes bewirkt und akzeptiere das Risiko bei falscher Verwendung."
                 }
             }
         },
@@ -156,7 +156,7 @@
                 },
                 "acknowledge_risk": {
                     "name": "Bestätigung",
-                    "description": "Ich akzeptiere das Risiko"
+                    "description": "Ich habe die Dokumentation von IDM gelesen, weiß was das setzen dieses Wertes bewirkt und akzeptiere das Risiko bei falscher Verwendung."
                 }
             }
         },
@@ -174,7 +174,7 @@
                 },
                 "acknowledge_risk": {
                     "name": "Bestätigung",
-                    "description": "Ich akzeptiere das Risiko"
+                    "description": "Ich habe die Dokumentation von IDM gelesen, weiß was das setzen dieses Wertes bewirkt und akzeptiere das Risiko bei falscher Verwendung."
                 }
             }
         },
@@ -192,7 +192,7 @@
                 },
                 "acknowledge_risk": {
                     "name": "Bestätigung",
-                    "description": "Ich akzeptiere das Risiko"
+                    "description": "Ich habe die Dokumentation von IDM gelesen, weiß was das setzen dieses Wertes bewirkt und akzeptiere das Risiko bei falscher Verwendung."
                 }
             }
         },
@@ -210,7 +210,7 @@
                 },
                 "acknowledge_risk": {
                     "name": "Bestätigung",
-                    "description": "Ich akzeptiere das Risiko"
+                    "description": "Ich habe die Dokumentation von IDM gelesen, weiß was das setzen dieses Wertes bewirkt und akzeptiere das Risiko bei falscher Verwendung."
                 }
             }
         },
@@ -228,7 +228,7 @@
                 },
                 "acknowledge_risk": {
                     "name": "Bestätigung",
-                    "description": "Ich akzeptiere das Risiko"
+                    "description": "Ich habe die Dokumentation von IDM gelesen, weiß was das setzen dieses Wertes bewirkt und akzeptiere das Risiko bei falscher Verwendung."
                 }
             }
         },
@@ -246,15 +246,12 @@
                 },
                 "acknowledge_risk": {
                     "name": "Bestätigung",
-                    "description": "Ich akzeptiere das Risiko"
+                    "description": "Ich habe die Dokumentation von IDM gelesen, weiß was das setzen dieses Wertes bewirkt und akzeptiere das Risiko bei falscher Verwendung."
                 }
             }
         }
     },
     "selector": {
-        "acknowledge_set_value": {
-            "value": "Ich habe die Dokumentation von IDM gelesen, weiß was das setzen dieses Wertes bewirkt und akzeptiere das Risiko bei falscher Verwendung."
-        },
         "room_mode_options": {
             "options": {
                 "off": "Aus",

--- a/custom_components/idm_heatpump/translations/en.json
+++ b/custom_components/idm_heatpump/translations/en.json
@@ -3,7 +3,7 @@
         "step": {
             "user": {
                 "title": "IDM Heat Pump",
-                "description": "If you need help with the configuration have a look here: https://github.com/kodebach/hacs-idm-heatpump",
+                "description": "If you need help with the configuration have a look [here]({docs_url}).",
                 "data": {
                     "display_name": "Display Name",
                     "hostname": "Hostname/IP"
@@ -20,7 +20,7 @@
                     "max_power_usage": "Maximum power draw"
                 },
                 "data_description": {
-                    "allow_fast_refresh": "Short refresh are blocked by default because of reports about possible issues (https://github.com/kodebach/hacs-idm-heatpump/issues/16).",
+                    "allow_fast_refresh": "Short refresh are blocked by default because of reports about possible issues (see [issue #16]({issue_url})).",
                     "max_power_usage": "The sensor 'Aktuelle Leistungsaufnahme Wärmepumpe' will be set to 'Unknown', if the heat pump sends a value above the maximum. This creates gaps in the history instead of impossibly high values, which would throw of the axis scaling. If no value is defined or it is set to 0, all values from the heat pump will be used directly."
                 }
             },
@@ -71,7 +71,7 @@
                     "max_power_usage": "Maximum power draw"
                 },
                 "data_description": {
-                    "allow_fast_refresh": "Short refresh are blocked by default because of reports about possible issues (https://github.com/kodebach/hacs-idm-heatpump/issues/16).",
+                    "allow_fast_refresh": "Short refresh are blocked by default because of reports about possible issues (see [issue #16]({issue_url})).",
                     "max_power_usage": "The sensor 'Aktuelle Leistungsaufnahme Wärmepumpe' will be set to 'Unknown', if the heat pump sends a value above the maximum. This creates gaps in the history instead of impossibly high values, which would throw of the axis scaling. If no value is defined or it is set to 0, all values from the heat pump will be used directly."
                 }
             },

--- a/custom_components/idm_heatpump/translations/en.json
+++ b/custom_components/idm_heatpump/translations/en.json
@@ -119,8 +119,8 @@
                     "description": "The value to send."
                 },
                 "acknowledge_risk": {
-                    "name": "Bestätigung",
-                    "description": "Ich akzeptiere das Risiko"
+                    "name": "Confirmation",
+                    "description": "I have read IDM's documentation, I know what effect setting this value has and I accept the risks in case of misuse."
                 }
             }
         },
@@ -138,7 +138,7 @@
                 },
                 "acknowledge_risk": {
                     "name": "Confirmation",
-                    "description": "I accept the risks"
+                    "description": "I have read IDM's documentation, I know what effect setting this value has and I accept the risks in case of misuse."
                 }
             }
         },
@@ -156,7 +156,7 @@
                 },
                 "acknowledge_risk": {
                     "name": "Confirmation",
-                    "description": "I accept the risks"
+                    "description": "I have read IDM's documentation, I know what effect setting this value has and I accept the risks in case of misuse."
                 }
             }
         },
@@ -174,7 +174,7 @@
                 },
                 "acknowledge_risk": {
                     "name": "Confirmation",
-                    "description": "I accept the risks"
+                    "description": "I have read IDM's documentation, I know what effect setting this value has and I accept the risks in case of misuse."
                 }
             }
         },
@@ -192,7 +192,7 @@
                 },
                 "acknowledge_risk": {
                     "name": "Confirmation",
-                    "description": "I accept the risks"
+                    "description": "I have read IDM's documentation, I know what effect setting this value has and I accept the risks in case of misuse."
                 }
             }
         },
@@ -210,7 +210,7 @@
                 },
                 "acknowledge_risk": {
                     "name": "Confirmation",
-                    "description": "I accept the risks"
+                    "description": "I have read IDM's documentation, I know what effect setting this value has and I accept the risks in case of misuse."
                 }
             }
         },
@@ -228,7 +228,7 @@
                 },
                 "acknowledge_risk": {
                     "name": "Confirmation",
-                    "description": "I accept the risks"
+                    "description": "I have read IDM's documentation, I know what effect setting this value has and I accept the risks in case of misuse."
                 }
             }
         },
@@ -246,15 +246,12 @@
                 },
                 "acknowledge_risk": {
                     "name": "Confirmation",
-                    "description": "I accept the risks"
+                    "description": "I have read IDM's documentation, I know what effect setting this value has and I accept the risks in case of misuse."
                 }
             }
         }
     },
     "selector": {
-        "acknowledge_set_value": {
-            "value": "I have read IDM's documentation, I know what effect setting this value has and I accept the risks in case of misuse."
-        },
         "room_mode_options": {
             "options": {
                 "off": "Off",


### PR DESCRIPTION
Fixes the `[TRANSLATIONS]` hassfest failures currently red on `master`. Two
independent, pre-existing issues, one per commit.

### 1. `acknowledge_risk` constant-selector label
hassfest's selector-translation schema only permits `choices`, `options`,
`unit_of_measurement` and `fields` under `selector.<key>` — there's no key for
a constant selector's caption, so `acknowledge_set_value` was rejected.

Since a constant selector's label can't be translated, the risk warning now
lives in the field `description` (which *is* translatable → stays bilingual
DE/EN), and the constant uses `label: ""` so it shows no stray `true`. The
"include optional field" checkbox remains the acknowledgment gesture — it
submits the fixed `true` that the service handler already gates on. Also fixes
German text that had leaked into the English `set_power` field.

### 2. URLs in translation strings
`translation_value_validator` rejects raw URLs (`allow_urls=False`) in both
step `description` and `data_description`. The help link and the fast-refresh
issue link are moved to `{docs_url}` / `{issue_url}` markdown-link placeholders,
injected at runtime via `description_placeholders`. Links stay clickable.

### Testing
Hassfest passes. 
Reconfigure shows the proper link in the 'allow faster polls' setting.
Correct description shows next to the 'Confirmation' checkbox when 'Developer Tools → Actions → idm_heatpump.set_temperature'